### PR TITLE
Close the program if mpv crashes

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -11,4 +11,5 @@ const (
 	TrayMessage
 	PlayerChanged
 	DownloadChanged
+	RequestShutdown
 )

--- a/ui/input.go
+++ b/ui/input.go
@@ -114,7 +114,7 @@ func InputLoop(exit chan struct{}) {
 				PassKeystroke(c)
 			}
 
-			events <- ev.Keystroke
+			eventsHndl.Post(ev.Keystroke)
 		case <-exit:
 			return
 		}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -161,6 +161,11 @@ func RenderLoop() {
 			if !ok {
 				return
 			}
+			if event == ev.RequestShutdown {
+				close(exitChan)
+				return
+			}
+
 			if event == ev.Resize {
 				UpdateDimensions(root)
 				renderMenu()


### PR DESCRIPTION
If mpv exits unexpectedly for any reason, close the program without waiting for output from the mpv communication channel.

This avoids a long standing deadlock condition that really annoys me.